### PR TITLE
Disable timeout of uploads sync process in `migrate` command

### DIFF
--- a/src/Service/Migration.php
+++ b/src/Service/Migration.php
@@ -213,6 +213,8 @@ class Migration
 
     public function newProcess($command)
     {
-        return new Process($command);
+        $process = new Process($command);
+        $process->setTimeout(null);
+        return $process;
     }
 }

--- a/tests/Service/MigrationTest.php
+++ b/tests/Service/MigrationTest.php
@@ -262,6 +262,7 @@ class MigrationTest extends TestCase
         $process = $migration->newProcess('command to run');
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals('command to run', $process->getCommandLine());
+        $this->assertNull($process->getTimeout());
     }
 
     public function testBeginStepNormal()


### PR DESCRIPTION
The default 60 second timeout of the Symfony Process component was causing the media upload sync process to end prematurely when a large sync was required. This commit disables that timeout so it will run forever.