### PR TITLE
Add `aws:start` and `aws:stop` commands

### DIFF
--- a/bin/wasm
+++ b/bin/wasm
@@ -49,5 +49,7 @@ $app->addCommands([
     new Db\Import($instanceFactory),
     new Migrate($instanceFactory),
     new Aws\Status($hostingStackCollection),
+    new Aws\Start($hostingStackCollection),
+    new Aws\Stop($hostingStackCollection),
 ]);
 $app->run();

--- a/src/Aws/HostingStackCollection.php
+++ b/src/Aws/HostingStackCollection.php
@@ -28,7 +28,7 @@ class HostingStackCollection
         }
 
         return array_map(function ($stack) {
-            return new HostingStack($stack);
+            return new HostingStack($stack, $this->cloudformation);
         }, $stacks);
     }
 

--- a/src/Aws/HostingStackCollection.php
+++ b/src/Aws/HostingStackCollection.php
@@ -32,6 +32,23 @@ class HostingStackCollection
         }, $stacks);
     }
 
+    /**
+     * @param string $stackName Name of the CloudFormation stack
+     * @return HostingStack
+     * @throws \Exception
+     */
+    public function getStack($stackName)
+    {
+        $results = $this->cloudformation->describeStacks([
+            'StackName' => $stackName,
+        ]);
+        $stack = $results['Stacks'][0];
+        if (!$this->isHostingStack($stack)) {
+            throw new \Exception('This is not a hosting stack');
+        }
+        return new HostingStack($stack, $this->cloudformation);
+    }
+
     protected function isHostingStack($description)
     {
         // If the stack name doesn't end with "dev", "staging" or "prod", it's not a hosting stack

--- a/src/Command/Aws/Start.php
+++ b/src/Command/Aws/Start.php
@@ -35,9 +35,12 @@ class Start extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stackName = $this->getStackName($input->getArgument('instance'));
-        $stack = $this->collection->getStack($stackName);
+        $instanceIdentifier = $input->getArgument('instance');
+        $stack = $this->collection->getStack(
+            $this->getStackName($instanceIdentifier)
+        );
         $stack->start();
+        $output->writeln("<info>Success:</info> <comment>$instanceIdentifier</comment> is starting");
     }
 
     /**

--- a/src/Command/Aws/Start.php
+++ b/src/Command/Aws/Start.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WpEcs\Command\Aws;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use WpEcs\Aws\HostingStackCollection;
+
+class Start extends Command
+{
+    /**
+     * @var HostingStackCollection
+     */
+    protected $collection;
+
+    public function __construct(HostingStackCollection $collection)
+    {
+        $this->collection = $collection;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('aws:start')
+            ->setDescription('Start an AWS hosting stack')
+            ->addArgument(
+                'instance',
+                InputArgument::REQUIRED,
+                'Instance identifier. Valid format: "<appname>:<env>"'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $stackName = $this->getStackName($input->getArgument('instance'));
+        $stack = $this->collection->getStack($stackName);
+        $stack->start();
+    }
+
+    /**
+     * @param string $instance
+     *
+     * @return string
+     */
+    protected function getStackName($instance)
+    {
+        return str_replace(':', '-', $instance);
+    }
+}

--- a/src/Command/Aws/Stop.php
+++ b/src/Command/Aws/Stop.php
@@ -44,9 +44,12 @@ class Stop extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $stackName = $this->getStackName($input->getArgument('instance'));
-        $stack = $this->collection->getStack($stackName);
+        $instanceIdentifier = $input->getArgument('instance');
+        $stack = $this->collection->getStack(
+            $this->getStackName($instanceIdentifier)
+        );
         $stack->stop();
+        $output->writeln("<info>Success:</info> <comment>$instanceIdentifier</comment> is being stopped");
     }
 
     /**

--- a/src/Command/Aws/Stop.php
+++ b/src/Command/Aws/Stop.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace WpEcs\Command\Aws;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use WpEcs\Aws\HostingStackCollection;
+
+class Stop extends Command
+{
+    /**
+     * @var HostingStackCollection
+     */
+    protected $collection;
+
+    public function __construct(HostingStackCollection $collection)
+    {
+        $this->collection = $collection;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('aws:stop')
+            ->setDescription('Stop an AWS hosting stack')
+            ->addArgument(
+                'instance',
+                InputArgument::REQUIRED,
+                'Instance identifier. Valid format: "<appname>:<env>"'
+            )
+            ->addOption(
+                'production',
+                'p',
+                InputOption::VALUE_NONE,
+                "Don't ask for confirmation before stopping a production instance"
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $stackName = $this->getStackName($input->getArgument('instance'));
+        $stack = $this->collection->getStack($stackName);
+        $stack->stop();
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $stackName = $this->getStackName($input->getArgument('instance'));
+
+        if (preg_match('/-prod$/', $stackName) && !$input->getOption('production')) {
+            $output->writeln("<error>It looks like you're trying to stop a production instance.</error>");
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion("Are you sure you want to do that? [y/n]\n", false);
+            if (!$helper->ask($input, $output, $question)) {
+                throw new RuntimeException('Aborting');
+            }
+        }
+    }
+
+    /**
+     * @param string $instance
+     *
+     * @return string
+     */
+    protected function getStackName($instance)
+    {
+        return str_replace(':', '-', $instance);
+    }
+}

--- a/tests/Aws/HostingStackCollectionTest.php
+++ b/tests/Aws/HostingStackCollectionTest.php
@@ -14,30 +14,30 @@ class HostingStackCollectionTest extends TestCase
         $collection = new HostingStackCollection(
             $this->mockCloudFormationClient()
         );
-        $stacks = $collection->getStacks();
+        $stacks     = $collection->getStacks();
 
         $this->assertCount(count($this->validHostingStackDescriptions()), $stacks);
         $this->assertContainsOnlyInstancesOf(HostingStack::class, $stacks);
 
         // Convert HostingStack objects into arrays so we can easily assert their values
-        $actualValues = array_map(function($stack) {
+        $actualValues = array_map(function ($stack) {
             return json_decode(json_encode($stack), true);
         }, $stacks);
 
         $expectedValues = [
             [
-                'appName' => 'example',
-                'env' => 'dev',
-                'isActive' => true,
+                'appName'    => 'example',
+                'env'        => 'dev',
+                'isActive'   => true,
                 'isUpdating' => false,
-                'family' => 'WordPress',
+                'family'     => 'WordPress',
             ],
             [
-                'appName' => 'example',
-                'env' => 'staging',
-                'isActive' => true,
+                'appName'    => 'example',
+                'env'        => 'staging',
+                'isActive'   => true,
                 'isUpdating' => false,
-                'family' => 'WordPress',
+                'family'     => 'WordPress',
             ],
         ];
 

--- a/tests/Aws/HostingStackTest.php
+++ b/tests/Aws/HostingStackTest.php
@@ -2,6 +2,7 @@
 
 namespace WpEcs\Tests\Aws;
 
+use Aws\CloudFormation\CloudFormationClient;
 use PHPUnit\Framework\TestCase;
 use WpEcs\Aws\HostingStack;
 
@@ -10,10 +11,10 @@ class HostingStackTest extends TestCase
     public function stackNameDataProvider()
     {
         return [
-            ['example-dev',     'example',  'dev'    ],
-            ['example-staging', 'example',  'staging'],
-            ['example-prod',    'example',  'prod'   ],
-            ['example2-dev',    'example2', 'dev'    ],
+            ['example-dev', 'example', 'dev'],
+            ['example-staging', 'example', 'staging'],
+            ['example-prod', 'example', 'prod'],
+            ['example2-dev', 'example2', 'dev'],
         ];
     }
 
@@ -27,23 +28,23 @@ class HostingStackTest extends TestCase
     public function testAppNameAndEnv($stackName, $expectedAppName, $expectedEnv)
     {
         $stackDescription = [
-            'StackId' => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
-            'StackName' => $stackName,
-            'Parameters' => [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => $stackName,
+            'Parameters'  => [
                 [
-                    'ParameterKey' => 'AppName',
+                    'ParameterKey'   => 'AppName',
                     'ParameterValue' => 'example',
                 ],
                 [
-                    'ParameterKey' => 'Active',
+                    'ParameterKey'   => 'Active',
                     'ParameterValue' => 'true',
                 ],
                 [
-                    'ParameterKey' => 'Environment',
+                    'ParameterKey'   => 'Environment',
                     'ParameterValue' => 'development',
                 ],
                 [
-                    'ParameterKey' => 'DockerImage',
+                    'ParameterKey'   => 'DockerImage',
                     'ParameterValue' => '000000000000.dkr.ecr.eu-west-2.amazonaws.com/wp/example:2c72c28-201810091200',
                 ],
             ],
@@ -51,7 +52,7 @@ class HostingStackTest extends TestCase
             // Some response fields omitted for brevity
         ];
 
-        $stack = new HostingStack($stackDescription);
+        $stack = new HostingStack($stackDescription, $this->mockCloudFormationClient());
 
         $this->assertEquals($expectedAppName, $stack->appName);
         $this->assertEquals($expectedEnv, $stack->env);
@@ -60,23 +61,23 @@ class HostingStackTest extends TestCase
     public function testAnActiveStack()
     {
         $stackDescription = [
-            'StackId' => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
-            'StackName' => 'example-dev',
-            'Parameters' => [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
                 [
-                    'ParameterKey' => 'AppName',
+                    'ParameterKey'   => 'AppName',
                     'ParameterValue' => 'example',
                 ],
                 [
-                    'ParameterKey' => 'Active',
+                    'ParameterKey'   => 'Active',
                     'ParameterValue' => 'true',
                 ],
                 [
-                    'ParameterKey' => 'Environment',
+                    'ParameterKey'   => 'Environment',
                     'ParameterValue' => 'development',
                 ],
                 [
-                    'ParameterKey' => 'DockerImage',
+                    'ParameterKey'   => 'DockerImage',
                     'ParameterValue' => '000000000000.dkr.ecr.eu-west-2.amazonaws.com/wp/example:2c72c28-201810091200',
                 ],
             ],
@@ -84,7 +85,7 @@ class HostingStackTest extends TestCase
             // Some response fields omitted for brevity
         ];
 
-        $stack = new HostingStack($stackDescription);
+        $stack = new HostingStack($stackDescription, $this->mockCloudFormationClient());
 
         $this->assertEquals(true, $stack->isActive);
         $this->assertEquals(false, $stack->isUpdating);
@@ -93,23 +94,23 @@ class HostingStackTest extends TestCase
     public function testAnInactiveStack()
     {
         $stackDescription = [
-            'StackId' => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
-            'StackName' => 'example-dev',
-            'Parameters' => [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
                 [
-                    'ParameterKey' => 'AppName',
+                    'ParameterKey'   => 'AppName',
                     'ParameterValue' => 'example',
                 ],
                 [
-                    'ParameterKey' => 'Active',
+                    'ParameterKey'   => 'Active',
                     'ParameterValue' => 'false',
                 ],
                 [
-                    'ParameterKey' => 'Environment',
+                    'ParameterKey'   => 'Environment',
                     'ParameterValue' => 'development',
                 ],
                 [
-                    'ParameterKey' => 'DockerImage',
+                    'ParameterKey'   => 'DockerImage',
                     'ParameterValue' => '000000000000.dkr.ecr.eu-west-2.amazonaws.com/wp/example:2c72c28-201810091200',
                 ],
             ],
@@ -117,7 +118,7 @@ class HostingStackTest extends TestCase
             // Some response fields omitted for brevity
         ];
 
-        $stack = new HostingStack($stackDescription);
+        $stack = new HostingStack($stackDescription, $this->mockCloudFormationClient());
 
         $this->assertEquals(false, $stack->isActive);
         $this->assertEquals(false, $stack->isUpdating);
@@ -127,10 +128,10 @@ class HostingStackTest extends TestCase
     {
         return [
             // [ stack status, is updating? ]
-            ['CREATE_IN_PROGRESS', true ],
-            ['UPDATE_IN_PROGRESS', true ],
-            ['CREATE_COMPLETE',    false],
-            ['UPDATE_COMPLETE',    false],
+            ['CREATE_IN_PROGRESS', true],
+            ['UPDATE_IN_PROGRESS', true],
+            ['CREATE_COMPLETE', false],
+            ['UPDATE_COMPLETE', false],
         ];
     }
 
@@ -143,23 +144,23 @@ class HostingStackTest extends TestCase
     public function testStackIsUpdating($status, $expect)
     {
         $stackDescription = [
-            'StackId' => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
-            'StackName' => 'example-dev',
-            'Parameters' => [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
                 [
-                    'ParameterKey' => 'AppName',
+                    'ParameterKey'   => 'AppName',
                     'ParameterValue' => 'example',
                 ],
                 [
-                    'ParameterKey' => 'Active',
+                    'ParameterKey'   => 'Active',
                     'ParameterValue' => 'true',
                 ],
                 [
-                    'ParameterKey' => 'Environment',
+                    'ParameterKey'   => 'Environment',
                     'ParameterValue' => 'development',
                 ],
                 [
-                    'ParameterKey' => 'DockerImage',
+                    'ParameterKey'   => 'DockerImage',
                     'ParameterValue' => '000000000000.dkr.ecr.eu-west-2.amazonaws.com/wp/example:2c72c28-201810091200',
                 ],
             ],
@@ -167,7 +168,7 @@ class HostingStackTest extends TestCase
             // Some response fields omitted for brevity
         ];
 
-        $stack = new HostingStack($stackDescription);
+        $stack = new HostingStack($stackDescription, $this->mockCloudFormationClient());
 
         $this->assertEquals(true, $stack->isActive);
         $this->assertEquals($expect, $stack->isUpdating);
@@ -193,19 +194,19 @@ class HostingStackTest extends TestCase
     public function testStackFamily($dockerImage, $expect)
     {
         $stackDescription = [
-            'StackId' => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
-            'StackName' => 'example-dev',
-            'Parameters' => [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
                 [
-                    'ParameterKey' => 'AppName',
+                    'ParameterKey'   => 'AppName',
                     'ParameterValue' => 'example',
                 ],
                 [
-                    'ParameterKey' => 'Active',
+                    'ParameterKey'   => 'Active',
                     'ParameterValue' => 'true',
                 ],
                 [
-                    'ParameterKey' => 'Environment',
+                    'ParameterKey'   => 'Environment',
                     'ParameterValue' => 'development',
                 ],
             ],
@@ -215,13 +216,206 @@ class HostingStackTest extends TestCase
 
         if ($dockerImage) {
             $stackDescription['Parameters'][] = [
-                'ParameterKey' => 'DockerImage',
+                'ParameterKey'   => 'DockerImage',
                 'ParameterValue' => $dockerImage,
             ];
         }
 
-        $stack = new HostingStack($stackDescription);
+        $stack = new HostingStack($stackDescription, $this->mockCloudFormationClient());
 
         $this->assertEquals($expect, $stack->family);
+    }
+
+    public function testStart()
+    {
+        $stackDescription = [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
+                [
+                    'ParameterKey'   => 'AppName',
+                    'ParameterValue' => 'example',
+                ],
+                [
+                    'ParameterKey'   => 'Active',
+                    'ParameterValue' => 'false',
+                ],
+                [
+                    'ParameterKey'   => 'Environment',
+                    'ParameterValue' => 'development',
+                ],
+            ],
+            'StackStatus' => 'UPDATE_COMPLETE',
+            // Some response fields omitted for brevity
+        ];
+
+        $cloudformation = $this->createPartialMock(
+            CloudFormationClient::class,
+            ['updateStack']
+        );
+
+        $cloudformation->expects($this->once())
+                       ->method('updateStack')
+                       ->with([
+                           'StackName'           => 'example-dev',
+                           'UsePreviousTemplate' => true,
+                           'Capabilities'        => ['CAPABILITY_IAM'],
+                           'Parameters'          => [
+                               [
+                                   'ParameterKey'     => 'AppName',
+                                   'UsePreviousValue' => true,
+                               ],
+                               [
+                                   'ParameterKey'   => 'Active',
+                                   'ParameterValue' => 'true',
+                               ],
+                               [
+                                   'ParameterKey'     => 'Environment',
+                                   'UsePreviousValue' => true,
+                               ],
+                           ],
+                       ]);
+
+        $stack = new HostingStack($stackDescription, $cloudformation);
+
+        $stack->start();
+    }
+
+    public function testStop()
+    {
+        $stackDescription = [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
+                [
+                    'ParameterKey'   => 'AppName',
+                    'ParameterValue' => 'example',
+                ],
+                [
+                    'ParameterKey'   => 'Active',
+                    'ParameterValue' => 'true',
+                ],
+                [
+                    'ParameterKey'   => 'Environment',
+                    'ParameterValue' => 'development',
+                ],
+            ],
+            'StackStatus' => 'UPDATE_COMPLETE',
+            // Some response fields omitted for brevity
+        ];
+
+        $cloudformation = $this->createPartialMock(
+            CloudFormationClient::class,
+            ['updateStack']
+        );
+
+        $cloudformation->expects($this->once())
+                       ->method('updateStack')
+                       ->with([
+                           'StackName'           => 'example-dev',
+                           'UsePreviousTemplate' => true,
+                           'Capabilities'        => ['CAPABILITY_IAM'],
+                           'Parameters'          => [
+                               [
+                                   'ParameterKey'     => 'AppName',
+                                   'UsePreviousValue' => true,
+                               ],
+                               [
+                                   'ParameterKey'   => 'Active',
+                                   'ParameterValue' => 'false',
+                               ],
+                               [
+                                   'ParameterKey'     => 'Environment',
+                                   'UsePreviousValue' => true,
+                               ],
+                           ],
+                       ]);
+
+        $stack = new HostingStack($stackDescription, $cloudformation);
+
+        $stack->stop();
+    }
+
+    public function testStartAnAlreadyRunningStack()
+    {
+        $stackDescription = [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
+                [
+                    'ParameterKey'   => 'AppName',
+                    'ParameterValue' => 'example',
+                ],
+                [
+                    'ParameterKey'   => 'Active',
+                    'ParameterValue' => 'true',
+                ],
+                [
+                    'ParameterKey'   => 'Environment',
+                    'ParameterValue' => 'development',
+                ],
+            ],
+            'StackStatus' => 'UPDATE_COMPLETE',
+            // Some response fields omitted for brevity
+        ];
+
+        $cloudformation = $this->createPartialMock(
+            CloudFormationClient::class,
+            ['updateStack']
+        );
+
+        $cloudformation->expects($this->never())
+                       ->method('updateStack');
+
+        $stack = new HostingStack($stackDescription, $cloudformation);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('This stack is already running');
+
+        $stack->start();
+    }
+
+    public function testStopAnAlreadyStoppedStack()
+    {
+        $stackDescription = [
+            'StackId'     => 'arn:aws:cloudformation:eu-west-2:000000000000:stack/example-dev/c96d3035-458a-5ae5-ada3-ee273c59e65a',
+            'StackName'   => 'example-dev',
+            'Parameters'  => [
+                [
+                    'ParameterKey'   => 'AppName',
+                    'ParameterValue' => 'example',
+                ],
+                [
+                    'ParameterKey'   => 'Active',
+                    'ParameterValue' => 'false',
+                ],
+                [
+                    'ParameterKey'   => 'Environment',
+                    'ParameterValue' => 'development',
+                ],
+            ],
+            'StackStatus' => 'UPDATE_COMPLETE',
+            // Some response fields omitted for brevity
+        ];
+
+        $cloudformation = $this->createPartialMock(
+            CloudFormationClient::class,
+            ['updateStack']
+        );
+
+        $cloudformation->expects($this->never())
+                       ->method('updateStack');
+
+        $stack = new HostingStack($stackDescription, $cloudformation);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('This stack is already stopped');
+
+        $stack->stop();
+    }
+
+    protected function mockCloudFormationClient()
+    {
+        return $this->createMock(CloudFormationClient::class);
     }
 }

--- a/tests/Command/Aws/StartTest.php
+++ b/tests/Command/Aws/StartTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace WpEcs\Tests\Command\Aws;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use WpEcs\Aws\HostingStack;
+use WpEcs\Aws\HostingStackCollection;
+use WpEcs\Command\Aws\Start;
+
+class StartTest extends TestCase
+{
+    public function testConfigure()
+    {
+        $command = $this->getSubject(false);
+        $this->assertInstanceOf(Start::class, $command);
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasArgument('instance'));
+        $this->assertEquals(1, $definition->getArgumentRequiredCount());
+    }
+
+    public function executeDataProvider() {
+        return [
+            // instance identifier, stack name
+            ['example:dev',     'example-dev'    ],
+            ['example:staging', 'example-staging'],
+            ['example:prod',    'example-prod'   ],
+        ];
+    }
+
+    /**
+     * @dataProvider executeDataProvider
+     */
+    public function testStop($instanceIdentifier, $stackName)
+    {
+        $command = $this->getSubject($stackName);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'instance' => $instanceIdentifier,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertContains("Success: $instanceIdentifier is starting", $output);
+    }
+
+    /**
+     * @param string|false $expectStackName Expect `HostingStackCollection::getStack` to be called with this stack name
+     *
+     * @return \Symfony\Component\Console\Command\Command
+     */
+    protected function getSubject($expectStackName)
+    {
+        $hostingStack = $this->createMock(HostingStack::class);
+        $hostingStack->expects($expectStackName ? $this->once() : $this->never())
+                     ->method('start');
+
+        $collection = $this->createMock(HostingStackCollection::class);
+        $collection->expects($expectStackName ? $this->once() : $this->never())
+                   ->method('getStack')
+                   ->with($expectStackName)
+                   ->willReturn($hostingStack);
+
+        $application = new Application();
+        $command = new Start($collection);
+        $application->add($command);
+        return $application->find('aws:start');
+    }
+}

--- a/tests/Command/Aws/StatusTest.php
+++ b/tests/Command/Aws/StatusTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Console\Tests\Helper\TableTest;
 use WpEcs\Aws\HostingStack;
 use WpEcs\Aws\HostingStackCollection;
 use WpEcs\Command\Aws\Status;

--- a/tests/Command/Aws/StopTest.php
+++ b/tests/Command/Aws/StopTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace WpEcs\Tests\Command\Aws;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+use WpEcs\Aws\HostingStack;
+use WpEcs\Aws\HostingStackCollection;
+use WpEcs\Command\Aws\Stop;
+
+class StopTest extends TestCase
+{
+    public function testConfigure()
+    {
+        $command = $this->getSubject(false, false);
+        $this->assertInstanceOf(Stop::class, $command);
+        $definition = $command->getDefinition();
+        $this->assertTrue($definition->hasArgument('instance'));
+        $this->assertTrue($definition->hasOption('production'));
+        $this->assertEquals(1, $definition->getArgumentRequiredCount());
+    }
+
+    public function executeDataProvider()
+    {
+        return [
+            // instance identifier, stack name
+            ['example:dev', 'example-dev'],
+            ['example:staging', 'example-staging'],
+        ];
+    }
+
+    /**
+     * @dataProvider executeDataProvider
+     */
+    public function testStopNonProduction($instanceIdentifier, $stackName)
+    {
+        $command       = $this->getSubject($stackName, true);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'instance' => $instanceIdentifier,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertContains("Success: $instanceIdentifier is being stopped", $output);
+    }
+
+    public function yesStrings()
+    {
+        return [
+            ['yes'],
+            ['y'],
+        ];
+    }
+
+    /**
+     * @param $yesString
+     * @dataProvider yesStrings
+     */
+    public function testStopProductionAndAnswerYes($yesString)
+    {
+        $instanceIdentifier = 'example:prod';
+        $stackName = 'example-prod';
+
+        $command = $this->getSubject($stackName, true);
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs([$yesString]);
+        $commandTester->execute([
+            'instance' => $instanceIdentifier,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertContains('Are you sure you want to do that?', $output);
+        $this->assertContains("Success: $instanceIdentifier is being stopped", $output);
+    }
+
+    public function noStrings()
+    {
+        return [
+            ['no'],
+            ['n'],
+        ];
+    }
+
+    /**
+     * @param string $noString
+     * @dataProvider noStrings
+     */
+    public function testStopProductionAndAnswerNo($noString)
+    {
+        $instanceIdentifier = 'example:prod';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Aborting');
+
+        $command = $this->getSubject(false, false);
+        $commandTester = new CommandTester($command);
+        $commandTester->setInputs([$noString]);
+        $commandTester->execute([
+            'instance' => $instanceIdentifier,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertContains('Are you sure you want to do that?', $output);
+    }
+
+    /**
+     * The command should stop a production instance, without interactive prompt,
+     * when called with the `--production` command line option
+     */
+    public function testStopProductionWithCommandLineFlag()
+    {
+        $instanceIdentifier = 'example:prod';
+        $stackName = 'example-prod';
+
+        $command = $this->getSubject($stackName, true);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'instance' => $instanceIdentifier,
+            '--production' => true,
+        ]);
+
+        $output = $commandTester->getDisplay();
+        $this->assertContains("Success: $instanceIdentifier is being stopped", $output);
+    }
+
+    /**
+     * @param string|false $expectStackName Expect `HostingStackCollection::getStack` to be called with this stack name
+     * @param bool $expectCallToStop Expect that `HostingStack::stop` is called once. If false, it should never be called.
+     *
+     * @return \Symfony\Component\Console\Command\Command
+     */
+    protected function getSubject($expectStackName, $expectCallToStop)
+    {
+        $hostingStack = $this->createMock(HostingStack::class);
+        $hostingStack->expects($expectCallToStop ? $this->once() : $this->never())
+                     ->method('stop');
+
+        $collection = $this->createMock(HostingStackCollection::class);
+        $collection->expects($expectStackName ? $this->once() : $this->never())
+                   ->method('getStack')
+                   ->with($expectStackName)
+                   ->willReturn($hostingStack);
+
+        $application = new Application();
+        $command = new Stop($collection);
+        $application->add($command);
+        return $application->find('aws:stop');
+    }
+}


### PR DESCRIPTION
These commands can be used to spin-down unused WordPress instances on AWS instances, which will save money by reducing resource usage.