### PR TITLE
Increase timeout for large sites

### DIFF
--- a/src/Command/Shell.php
+++ b/src/Command/Shell.php
@@ -58,6 +58,7 @@ class Shell extends Command
             ['-t']
         );
         $process->setTty(true);
+        $process->setTimeout(300);
         $process->run();
     }
 }

--- a/src/Service/Migration.php
+++ b/src/Service/Migration.php
@@ -214,7 +214,7 @@ class Migration
     public function newProcess($command)
     {
         $process = new Process($command);
-        $process->setTimeout(null);
+        $process->setTimeout(5400); // 90 minutes max for large buckets
         return $process;
     }
 }

--- a/src/Wordpress/AbstractInstance.php
+++ b/src/Wordpress/AbstractInstance.php
@@ -109,7 +109,9 @@ abstract class AbstractInstance
             fwrite($file, $buffer);
         };
 
+        $process->setTimeout(300);
         $process->disableOutput();
+
         $process->mustRun($saveOutputStream);
     }
 
@@ -124,6 +126,7 @@ abstract class AbstractInstance
     {
         $process = $this->newCommand('wp --allow-root db import -', ['-i']);
         $process->setInput($file);
+        $process->setTimeout(300);
         $process->mustRun();
     }
 }

--- a/src/Wordpress/AwsInstance.php
+++ b/src/Wordpress/AwsInstance.php
@@ -46,6 +46,7 @@ class AwsInstance extends AbstractInstance
         
         $command = $this->prepareCommand($command, $dockerOptions, $sshOptions);
         $process = new Process($command);
+        $process->setTimeout(300);
 
         return $process;
     }

--- a/src/Wordpress/LocalInstance.php
+++ b/src/Wordpress/LocalInstance.php
@@ -60,6 +60,7 @@ class LocalInstance extends AbstractInstance
     protected function newProcess($command)
     {
         $process = new Process($command);
+        $process->setTimeout(1800);
         $process->setWorkingDirectory($this->workingDirectory);
 
         return $process;

--- a/tests/Service/MigrationTest.php
+++ b/tests/Service/MigrationTest.php
@@ -262,7 +262,7 @@ class MigrationTest extends TestCase
         $process = $migration->newProcess('command to run');
         $this->assertInstanceOf(Process::class, $process);
         $this->assertEquals('command to run', $process->getCommandLine());
-        $this->assertNull($process->getTimeout());
+        $this->assertNotNull($process->getTimeout());
     }
 
     public function testBeginStepNormal()


### PR DESCRIPTION
WASM fails when migrating, exporting and importing large sites. The NULL value in Process::setTimeout() may not have had the desired impact and a Process without a setTimeout declaration was limited to 60 seconds.

This release extends timeout to 5 minutes for DB and general shell operations and 90 minutes for AWS bucket synchronization.